### PR TITLE
Add Reposilite publish CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,31 @@
+name: Publish to Reposilite
+
+on:
+  push:
+    branches: [ master ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+
+      - name: Build & publish to Reposilite
+        env:
+          # Reposilite token, injected from repo/org secrets — never committed.
+          ORG_GRADLE_PROJECT_AtlasEngineUsername: ${{ secrets.REPOSILITE_USERNAME }}
+          ORG_GRADLE_PROJECT_AtlasEnginePassword: ${{ secrets.REPOSILITE_PASSWORD }}
+        run: ./gradlew publish --no-daemon --stacktrace

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,8 +36,8 @@ publishing {
 
     repositories {
         maven {
-            name = "WorldSeed"
-            url = uri("https://reposilite.worldseed.online/public")
+            name = "AtlasEngine"
+            url = uri("https://reposilite.atlasengine.ca/public")
             credentials(PasswordCredentials::class)
             authentication {
                 create<BasicAuthentication>("basic")


### PR DESCRIPTION
Adds .github/workflows/publish.yml — builds with JDK 21 and runs ./gradlew publish on push to master (+ manual dispatch). Also migrates publishing from the retired reposilite.worldseed.online to reposilite.atlasengine.ca/public (repo name -> AtlasEngine). Credentials from secrets REPOSILITE_USERNAME / REPOSILITE_PASSWORD — add them before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)